### PR TITLE
new begin() with mostly free pin selection

### DIFF
--- a/Adafruit_NeoPixel_ZeroDMA.h
+++ b/Adafruit_NeoPixel_ZeroDMA.h
@@ -13,6 +13,7 @@ class Adafruit_NeoPixel_ZeroDMA : public Adafruit_NeoPixel {
   Adafruit_NeoPixel_ZeroDMA(void);
   ~Adafruit_NeoPixel_ZeroDMA();
 
+  boolean     begin(SERCOM *sercom, Sercom *sercomBase, uint8_t dmacID, uint8_t mosi, uint8_t miso, uint8_t sck, SercomSpiTXPad padTX, SercomRXPad padRX, EPioType pinFunc);
   boolean     begin(void);
   void        show(),
               setBrightness(uint8_t);


### PR DESCRIPTION
User can call new begin function like this:
```strip.begin(&sercom4, SERCOM4, SERCOM4_DMAC_ID_TX, 22, 23, 24, SPI_PAD_0_SCK_3, SERCOM_RX_PAD_2, PIO_SERCOM_ALT);```