### PR TITLE
rename and make begin(..) public again

### DIFF
--- a/Adafruit_NeoPixel_ZeroDMA.cpp
+++ b/Adafruit_NeoPixel_ZeroDMA.cpp
@@ -127,11 +127,11 @@ struct {
     @param pinFunc The pinmux setup for which 'type' of pinmux we use
     @returns True or false on success
 */
-boolean Adafruit_NeoPixel_ZeroDMA::_begin(SERCOM *sercom, Sercom *sercomBase,
-                                          uint8_t dmacID, uint8_t mosi,
-                                          uint8_t miso, uint8_t sck,
-                                          SercomSpiTXPad padTX,
-                                          SercomRXPad padRX, EPioType pinFunc) {
+boolean Adafruit_NeoPixel_ZeroDMA::begin(SERCOM *sercom, Sercom *sercomBase,
+                                         uint8_t dmacID, uint8_t mosi,
+                                         uint8_t miso, uint8_t sck,
+                                         SercomSpiTXPad padTX,
+                                         SercomRXPad padRX, EPioType pinFunc) {
 
   if (mosi != pin)
     return false; // Invalid pin
@@ -315,10 +315,10 @@ boolean Adafruit_NeoPixel_ZeroDMA::begin(void) {
 #ifdef __SAMD51__
   toggleMask = 0; // Using library's normal SERCOM DMA technique
 #endif
-  return _begin(sercomTable[i].sercom, sercomTable[i].sercomBase,
-                sercomTable[i].dmacID, sercomTable[i].mosi, sercomTable[i].miso,
-                sercomTable[i].sck, sercomTable[i].padTX, sercomTable[i].padRX,
-                sercomTable[i].pinFunc);
+  return begin(sercomTable[i].sercom, sercomTable[i].sercomBase,
+               sercomTable[i].dmacID, sercomTable[i].mosi, sercomTable[i].miso,
+               sercomTable[i].sck, sercomTable[i].padTX, sercomTable[i].padRX,
+               sercomTable[i].pinFunc);
 }
 
 /** @brief Convert the NeoPixel buffer to larger DMA buffer and start xfer

--- a/Adafruit_NeoPixel_ZeroDMA.h
+++ b/Adafruit_NeoPixel_ZeroDMA.h
@@ -16,6 +16,9 @@ public:
   ~Adafruit_NeoPixel_ZeroDMA();
 
   boolean begin(void);
+  boolean begin(SERCOM *sercom, Sercom *sercomBase, uint8_t dmacID,
+                 uint8_t mosi, uint8_t miso, uint8_t sck, SercomSpiTXPad padTX,
+                 SercomRXPad padRX, EPioType pinFunc);
   void show();
   void setBrightness(uint8_t);
   uint8_t getBrightness() const;
@@ -39,9 +42,6 @@ protected:
   uint8_t toggleMask; // Port bit to toggle
 #endif
 
-  boolean _begin(SERCOM *sercom, Sercom *sercomBase, uint8_t dmacID,
-                 uint8_t mosi, uint8_t miso, uint8_t sck, SercomSpiTXPad padTX,
-                 SercomRXPad padRX, EPioType pinFunc);
 };
 
 #endif // _ADAFRUIT_NEOPIXEL_ZERODMA_H_


### PR DESCRIPTION
solves #12 
_begin (..) renamed back to begin(..)
begin(..) is now public again
...pretty the same as #5 