### PR TITLE
rename and make begin(..) public again

### DIFF
--- a/Adafruit_NeoPixel_ZeroDMA.cpp
+++ b/Adafruit_NeoPixel_ZeroDMA.cpp
@@ -75,10 +75,10 @@ Adafruit_NeoPixel_ZeroDMA::~Adafruit_NeoPixel_ZeroDMA() {
     @param pinFunc The pinmux setup for which 'type' of pinmux we use
     @returns True or false on success
 */
-boolean Adafruit_NeoPixel_ZeroDMA::_begin(SERCOM *sercom, Sercom *sercomBase,
-                                          uint8_t dmacID, uint8_t mosi,
-                                          SercomSpiTXPad padTX,
-                                          EPioType pinFunc) {
+boolean Adafruit_NeoPixel_ZeroDMA::begin(SERCOM *sercom, Sercom *sercomBase,
+                                         uint8_t dmacID, uint8_t mosi,
+                                         SercomSpiTXPad padTX,
+                                         EPioType pinFunc) {
 
   if (mosi != pin)
     return false; // Invalid pin
@@ -346,9 +346,9 @@ boolean Adafruit_NeoPixel_ZeroDMA::begin(void) {
 #ifdef __SAMD51__
   toggleMask = 0; // Using library's normal SERCOM DMA technique
 #endif
-  return _begin(sercomTable[i].sercom, sercomTable[i].sercomBase,
-                sercomTable[i].dmacID, sercomTable[i].mosi,
-                sercomTable[i].padTX, sercomTable[i].pinFunc);
+  return begin(sercomTable[i].sercom, sercomTable[i].sercomBase,
+               sercomTable[i].dmacID, sercomTable[i].mosi,
+               sercomTable[i].padTX, sercomTable[i].pinFunc);
 }
 
 /** @brief Convert the NeoPixel buffer to larger DMA buffer and start xfer

--- a/Adafruit_NeoPixel_ZeroDMA.h
+++ b/Adafruit_NeoPixel_ZeroDMA.h
@@ -16,6 +16,8 @@ public:
   ~Adafruit_NeoPixel_ZeroDMA();
 
   boolean begin(void);
+  boolean begin(SERCOM *sercom, Sercom *sercomBase, uint8_t dmacID,
+                uint8_t mosi, SercomSpiTXPad padTX, EPioType pinFunc);
   void show();
   void setBrightness(uint8_t);
   uint8_t getBrightness() const;
@@ -39,8 +41,6 @@ protected:
   uint8_t toggleMask; // Port bit to toggle
 #endif
 
-  boolean _begin(SERCOM *sercom, Sercom *sercomBase, uint8_t dmacID,
-                 uint8_t mosi, SercomSpiTXPad padTX, EPioType pinFunc);
 };
 
 #endif // _ADAFRUIT_NEOPIXEL_ZERODMA_H_

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit DMA neopixel library
-version=1.2.0
+version=1.2.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for NeoPixel DMA on SAMD21 and SAMD51 microcontrollers


### PR DESCRIPTION
solves #12
_begin (..) renamed back to begin(..)
begin(..) is now public again
...pretty the same as #5