### PR TITLE
Enable using MO/A10/D10 for NeoPixels DMA on the QT PY

### DIFF
--- a/pins.h
+++ b/pins.h
@@ -298,6 +298,17 @@ struct {
   &sercom0, SERCOM0, SERCOM0_DMAC_ID_TX,    0, SPI_PAD_0_SCK_1, PIO_SERCOM_ALT,
 #endif
 
+#if defined(ADAFRUIT_QTPY_M0)
+  // All of the pins NeoPixels can use for DMA (SDA/D4, TX/A6/D6, MO/A10/D10)
+  // are also needed for other peripherals (I2C, Serial1, SPI, respectively),
+  // so using any of them means giving up the type of peripheral associated 
+  // with that pin. Given that other boards allow an option of using MOSI pin
+  // (but losing SPI in the process), the most reasonable tradeoff for DMA
+  // NeoPixels on the QT PY is probably SPI. So, using DMA NeoPixels means
+  // no SPI peripherals, sorry.
+  &sercom2, SERCOM2, SERCOM2_DMAC_ID_TX, MOSI, SPI_PAD_2_SCK_3, PIO_SERCOM_ALT,
+#endif  
+
 #if defined(USB_PID) && (USB_PID == 0x804d) // ARDUINO ZERO
   &sercom1, SERCOM1, SERCOM1_DMAC_ID_TX,   12, SPI_PAD_3_SCK_1, PIO_SERCOM,
   &sercom2, SERCOM2, SERCOM2_DMAC_ID_TX,    5, SPI_PAD_3_SCK_1, PIO_SERCOM,

--- a/pins.h
+++ b/pins.h
@@ -299,14 +299,18 @@ struct {
 #endif
 
 #if defined(ADAFRUIT_QTPY_M0)
-  // All of the pins NeoPixels can use for DMA (SDA/D4, TX/A6/D6, MO/A10/D10)
-  // are also needed for other peripherals (I2C, Serial1, SPI, respectively),
-  // so using any of them means giving up the type of peripheral associated 
-  // with that pin. Given that other boards allow an option of using MOSI pin
-  // (but losing SPI in the process), the most reasonable tradeoff for DMA
-  // NeoPixels on the QT PY is probably SPI. So, using DMA NeoPixels means
-  // no SPI peripherals, sorry.
+  // We can't use SERCOM0 because Serial1 uses it so that rules out TX/A6/D6.
+  // That leaves 3 other possible SERCOM/pin combinations:
+  //  * SERCOM1 + SDA/D4 (used for I2C)
+  //  * SERCOM2 + MOSI/A10/D10 (used for SPI)
+  //  * SERCOM3 + PIN_SPI1_MOSI/D16) (used for the SPI Flash chip that can be soldered 
+  //    onto the bottom)
+  // Since using those pins means giving up the associated peripheral,
+  // and since I2C is featured prominently on the QT Py, it makes the most
+  // sense to enable DMA Neopixels on the MOSI pins, though it means sacrificing
+  // either SPI peripherals or the (optional) flash chip.  Sorry.
   &sercom2, SERCOM2, SERCOM2_DMAC_ID_TX, MOSI, SPI_PAD_2_SCK_3, PIO_SERCOM_ALT,
+  &sercom3, SERCOM3, SERCOM3_DMAC_ID_TX,   16, SPI_PAD_0_SCK_1, PIO_SERCOM,
 #endif  
 
 #if defined(USB_PID) && (USB_PID == 0x804d) // ARDUINO ZERO


### PR DESCRIPTION
I have had cases with the QT PY where I've wished to use IR receivers or other hardware that generally cannot be used at the same time as NeoPixels. Since the QT PY uses a SAMD21 however, it should be capable of allowing the use of DMA for NeoPixels, freeing up the CPU for the other hardware. This PR enables using DMA NeoPixels on pin M0/A10/D10, however doing so comes with the caveat that SPI peripherals cannot be used at the same time as DMA NeoPixels given their use of the MOSI pin. I think this trade-off can be worth it in many cases, as the QT PY prominently features I2C as an alternative, and SPI may not be as critical for most people. Also, there is precedent in enabling the MOSI pin at the expense of SPI peripherals for several other boards, so it seems like a trade-off that would be consistent.
