### PR TITLE
Add support for NeoKey Trinkey

### DIFF
--- a/pins.h
+++ b/pins.h
@@ -313,6 +313,11 @@ struct {
   &sercom3, SERCOM3, SERCOM3_DMAC_ID_TX,   16, SPI_PAD_0_SCK_1, PIO_SERCOM,
 #endif  
 
+#if defined(ADAFRUIT_NEOKEYTRINKEY_M0)
+  // Onboard NeoPixel
+  &sercom2, SERCOM2, SERCOM2_DMAC_ID_TX,    0, SPI_PAD_3_SCK_1, PIO_SERCOM,
+#endif  
+
 #if defined(USB_PID) && (USB_PID == 0x804d) // ARDUINO ZERO
   &sercom1, SERCOM1, SERCOM1_DMAC_ID_TX,   12, SPI_PAD_3_SCK_1, PIO_SERCOM,
   &sercom2, SERCOM2, SERCOM2_DMAC_ID_TX,    5, SPI_PAD_3_SCK_1, PIO_SERCOM,


### PR DESCRIPTION
This PR adds DMA support for the NeoKey Trinkey's onboard NeoPixel. I'm not sure if you're interested in merging it, but my reasoning was I could have some kind of rainbow pattern cycling on the NeoPixel while it was typing out a string of characters.

Tested by replacing the NeoPixel library in the HID and cap touch example from the learn guide with this patched DMA version.

Side note: The schematic for the NeoKey Trinkey mislabels PA15 as SERCOM3; It is SERCOM2 or SERCOM4 (Alt function).