### PR TITLE
"_begin"-function is public

### DIFF
--- a/Adafruit_NeoPixel_ZeroDMA.cpp
+++ b/Adafruit_NeoPixel_ZeroDMA.cpp
@@ -75,7 +75,7 @@ Adafruit_NeoPixel_ZeroDMA::~Adafruit_NeoPixel_ZeroDMA() {
     @param pinFunc The pinmux setup for which 'type' of pinmux we use
     @returns True or false on success
 */
-boolean Adafruit_NeoPixel_ZeroDMA::_begin(SERCOM *sercom, Sercom *sercomBase,
+bool Adafruit_NeoPixel_ZeroDMA::begin(SERCOM *sercom, Sercom *sercomBase,
                                           uint8_t dmacID, uint8_t mosi,
                                           SercomSpiTXPad padTX,
                                           EPioType pinFunc) {
@@ -244,7 +244,7 @@ static void dmaCallback(Adafruit_ZeroDMA *dma) { lastBitTime = micros(); }
 /** @brief Initialize SPI sercom and DMA
     @returns True
  */
-boolean Adafruit_NeoPixel_ZeroDMA::begin(void) {
+bool Adafruit_NeoPixel_ZeroDMA::begin(void) {
 
   uint8_t i;
   for (i = 0; (i < N_SERCOMS) && (sercomTable[i].mosi != pin); i++)
@@ -346,7 +346,7 @@ boolean Adafruit_NeoPixel_ZeroDMA::begin(void) {
 #ifdef __SAMD51__
   toggleMask = 0; // Using library's normal SERCOM DMA technique
 #endif
-  return _begin(sercomTable[i].sercom, sercomTable[i].sercomBase,
+  return begin(sercomTable[i].sercom, sercomTable[i].sercomBase,
                 sercomTable[i].dmacID, sercomTable[i].mosi,
                 sercomTable[i].padTX, sercomTable[i].pinFunc);
 }

--- a/Adafruit_NeoPixel_ZeroDMA.cpp
+++ b/Adafruit_NeoPixel_ZeroDMA.cpp
@@ -76,9 +76,8 @@ Adafruit_NeoPixel_ZeroDMA::~Adafruit_NeoPixel_ZeroDMA() {
     @returns True or false on success
 */
 bool Adafruit_NeoPixel_ZeroDMA::begin(SERCOM *sercom, Sercom *sercomBase,
-                                          uint8_t dmacID, uint8_t mosi,
-                                          SercomSpiTXPad padTX,
-                                          EPioType pinFunc) {
+                                      uint8_t dmacID, uint8_t mosi,
+                                      SercomSpiTXPad padTX, EPioType pinFunc) {
 
   if (mosi != pin)
     return false; // Invalid pin
@@ -347,8 +346,8 @@ bool Adafruit_NeoPixel_ZeroDMA::begin(void) {
   toggleMask = 0; // Using library's normal SERCOM DMA technique
 #endif
   return begin(sercomTable[i].sercom, sercomTable[i].sercomBase,
-                sercomTable[i].dmacID, sercomTable[i].mosi,
-                sercomTable[i].padTX, sercomTable[i].pinFunc);
+               sercomTable[i].dmacID, sercomTable[i].mosi, sercomTable[i].padTX,
+               sercomTable[i].pinFunc);
 }
 
 /** @brief Convert the NeoPixel buffer to larger DMA buffer and start xfer

--- a/Adafruit_NeoPixel_ZeroDMA.h
+++ b/Adafruit_NeoPixel_ZeroDMA.h
@@ -40,7 +40,6 @@ protected:
   // that matrix, not arbitrary-length strips, so the waste is localized.
   uint8_t toggleMask; // Port bit to toggle
 #endif
-
 };
 
 #endif // _ADAFRUIT_NEOPIXEL_ZERODMA_H_

--- a/Adafruit_NeoPixel_ZeroDMA.h
+++ b/Adafruit_NeoPixel_ZeroDMA.h
@@ -15,8 +15,8 @@ public:
   Adafruit_NeoPixel_ZeroDMA(void);
   ~Adafruit_NeoPixel_ZeroDMA();
 
-  boolean begin(void);
-  boolean _begin(SERCOM *sercom, Sercom *sercomBase, uint8_t dmacID,
+  bool begin(void);
+  bool begin(SERCOM *sercom, Sercom *sercomBase, uint8_t dmacID,
                  uint8_t mosi, SercomSpiTXPad padTX, EPioType pinFunc);
   void show();
   void setBrightness(uint8_t);

--- a/Adafruit_NeoPixel_ZeroDMA.h
+++ b/Adafruit_NeoPixel_ZeroDMA.h
@@ -16,8 +16,8 @@ public:
   ~Adafruit_NeoPixel_ZeroDMA();
 
   bool begin(void);
-  bool begin(SERCOM *sercom, Sercom *sercomBase, uint8_t dmacID,
-                 uint8_t mosi, SercomSpiTXPad padTX, EPioType pinFunc);
+  bool begin(SERCOM *sercom, Sercom *sercomBase, uint8_t dmacID, uint8_t mosi,
+             SercomSpiTXPad padTX, EPioType pinFunc);
   void show();
   void setBrightness(uint8_t);
   uint8_t getBrightness() const;

--- a/Adafruit_NeoPixel_ZeroDMA.h
+++ b/Adafruit_NeoPixel_ZeroDMA.h
@@ -16,6 +16,8 @@ public:
   ~Adafruit_NeoPixel_ZeroDMA();
 
   boolean begin(void);
+  boolean _begin(SERCOM *sercom, Sercom *sercomBase, uint8_t dmacID,
+                 uint8_t mosi, SercomSpiTXPad padTX, EPioType pinFunc);
   void show();
   void setBrightness(uint8_t);
   uint8_t getBrightness() const;
@@ -39,8 +41,6 @@ protected:
   uint8_t toggleMask; // Port bit to toggle
 #endif
 
-  boolean _begin(SERCOM *sercom, Sercom *sercomBase, uint8_t dmacID,
-                 uint8_t mosi, SercomSpiTXPad padTX, EPioType pinFunc);
 };
 
 #endif // _ADAFRUIT_NEOPIXEL_ZERODMA_H_


### PR DESCRIPTION
for more flexibility declare _begin as public

allows experienced user use almost any pin.

Example:
_begin(&sercom4, SERCOM4, SERCOM4_DMAC_ID_TX, 22, SPI_PAD_0_SCK_3, PIO_SERCOM_ALT);

Based on discussion in #1, #5, #14 , #17 

P.S. we can also rename *_begin* to *begin*...